### PR TITLE
fix: make logged-in routes work

### DIFF
--- a/client/routes.js
+++ b/client/routes.js
@@ -18,7 +18,7 @@ class Routes extends Component {
   }
 
   render() {
-    const {loggedIn} = this.props
+    const loggedIn = this.props.isLoggedIn
     const guest = !loggedIn
 
     // You might be wondering why we haave to repeat the guest / loggedIn


### PR DESCRIPTION
A bug in the routes file was preventing any logged-in-only routes from working.