### PR TITLE
build: ensure we deploy css to heroku

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -23,7 +23,7 @@ set -e
 function cleanup_at_exit {
   # return to your master branch
   git checkout master
-  
+
   # remove the deploy branch
   git branch -D deploy
 }
@@ -37,7 +37,7 @@ git checkout -b deploy
 webpack -p
 
 # "force" add the otherwise gitignored build files
-git add -f public/bundle.js public/bundle.js.map
+git add -f public/bundle.js public/style.css
 
 # create a commit, even if nothing changed
 git commit --allow-empty -m 'Deploying'


### PR DESCRIPTION
I sure don't know how to write a test for this, but here's what was happening:
- we have bundle.js and style.css .gitignore'd (as we should)
- boilermaker's deploy script has to check things into a branch on git to deploy them to heroku
- it does this by having a fixed list of files to `git add -f`

So the fix was just to find the part of the script that does that and also add style.css to its force list.