### PR TITLE
feature: merge existing cart with guest cart on login

### DIFF
--- a/server/cartMiddleware.js
+++ b/server/cartMiddleware.js
@@ -50,11 +50,11 @@ class CartMiddleware {
 
       if (guestCart && !userCart) {
         guestCart.setUser(this.req.user)
+        this.req.session.cartId = null
       } else {
-        // what do we do when they have items in their
-        // guest cart but log into an account that already
-        // has a cart?
-        console.warn("cartMiddleware: conflict, cant't save guest cart to user")
+        await userCart.mergeFrom(guestCart)
+        this.req.session.cartId = null
+        await guestCart.destroy()
       }
     }
   }

--- a/server/db/models/order.spec.js
+++ b/server/db/models/order.spec.js
@@ -22,88 +22,129 @@ describe('Order model', () => {
   describe('instance methods', () => {
     const Product = db.model('product')
 
-    let product
-    let order
+    let product1
+    let product2
+    let order1
+    let order2
 
     beforeEach(async () => {
-      order = await Order.create()
-      product = await Product.create({
+      order1 = await Order.create()
+      order2 = await Order.create()
+      product1 = await Product.create({
         name: 'product a',
         price: 5
+      })
+      product2 = await Product.create({
+        name: 'product b',
+        price: 10
       })
     })
 
     describe('getQuantities', () => {
       it('includes quantity as .order_item.quantity', async () => {
-        await order.addProduct(product, {through: {quantity: 10}})
-        const products = await order.getQuantities()
+        await order1.addProduct(product1, {through: {quantity: 10}})
+        const products = await order1.getQuantities()
         expect(products[0].order_item.quantity).to.equal(10)
       })
     })
 
     describe('getQuantity', () => {
       it('returns the quantity of a product in the order', async () => {
-        await order.addProduct(product, {through: {quantity: 10}})
-        const quantity = await order.getQuantity(product)
+        await order1.addProduct(product1, {through: {quantity: 10}})
+        const quantity = await order1.getQuantity(product1)
         expect(quantity).to.be.equal(10)
       })
 
       it('can accept a numeric product id', async () => {
-        await order.addProduct(product, {through: {quantity: 10}})
-        const quantity = await order.getQuantity(product.id)
+        await order1.addProduct(product1, {through: {quantity: 10}})
+        const quantity = await order1.getQuantity(product1.id)
         expect(quantity).to.be.equal(10)
       })
 
       it('returns 0 if the product is not present', async () => {
-        const quantity = await order.getQuantity(product.id)
+        const quantity = await order1.getQuantity(product1.id)
         expect(quantity).to.be.equal(0)
       })
     })
 
     describe('setQuantity', () => {
       it('adds an item to the order if not present', async () => {
-        await order.setQuantity(product, 2)
-        const products = await order.getProducts({
+        await order1.setQuantity(product1, 2)
+        const products = await order1.getProducts({
           joinTableAttributes: ['quantity']
         })
         expect(products).to.be.an('array')
-        expect(products[0].id).to.equal(product.id)
+        expect(products[0].id).to.equal(product1.id)
         expect(products[0].order_item.quantity).to.equal(2)
       })
 
       it('can accept the product as an id', async () => {
-        await order.setQuantity(product.id, 2)
-        const products = await order.getProducts({
+        await order1.setQuantity(product1.id, 2)
+        const products = await order1.getProducts({
           joinTableAttributes: ['quantity']
         })
         expect(products).to.be.an('array')
-        expect(products[0].id).to.equal(product.id)
+        expect(products[0].id).to.equal(product1.id)
         expect(products[0].order_item.quantity).to.equal(2)
       })
 
       it('updates the quantity if item already present', async () => {
-        await order.setQuantity(product, 1)
-        await order.setQuantity(product, 2)
-        const products = await order.getProducts({
+        await order1.setQuantity(product1, 1)
+        await order1.setQuantity(product1, 2)
+        const products = await order1.getProducts({
           joinTableAttributes: ['quantity']
         })
-        expect(products[0].id).to.equal(product.id)
+        expect(products[0].id).to.equal(product1.id)
         expect(products[0].order_item.quantity).to.equal(2)
       })
 
       it('removes an item from the order if the quantity is 0', async () => {
-        await order.setQuantity(product, 2)
-        await order.setQuantity(product, 0)
-        const products = await order.getProducts()
+        await order1.setQuantity(product1, 2)
+        await order1.setQuantity(product1, 0)
+        const products = await order1.getProducts()
         return expect(products).to.be.empty
       })
 
       it('removes idempotently', async () => {
-        await order.setQuantity(product, 2)
-        await order.setQuantity(product, 0)
-        await order.setQuantity(product, 0)
-        const products = await order.getProducts()
+        await order1.setQuantity(product1, 2)
+        await order1.setQuantity(product1, 0)
+        await order1.setQuantity(product1, 0)
+        const products = await order1.getProducts()
         return expect(products).to.be.empty
+      })
+    })
+
+    describe('mergeFrom', () => {
+      it('adds the items in another order to this one', async () => {
+        await order1.setQuantity(product1, 5)
+        await order2.setQuantity(product2, 10)
+        await order1.mergeFrom(order2)
+        const products = await order1.getProducts()
+        const itemQuantities = products.map(item => [
+          item.id,
+          item.order_item.quantity
+        ])
+        expect(itemQuantities).to.have.deep.members([
+          [product1.id, 5],
+          [product2.id, 10]
+        ])
+      })
+
+      it('takes the larger quantity if an item is in both orders', async () => {
+        await order1.setQuantity(product1, 5)
+        await order1.setQuantity(product2, 3)
+        await order2.setQuantity(product1, 4)
+        await order2.setQuantity(product2, 10)
+        await order1.mergeFrom(order2)
+        const products = await order1.getProducts()
+        const itemQuantities = products.map(item => [
+          item.id,
+          item.order_item.quantity
+        ])
+        expect(itemQuantities).to.have.deep.members([
+          [product1.id, 5],
+          [product2.id, 10]
+        ])
       })
     })
   })


### PR DESCRIPTION
### Assignee Tasks

* [x] added unit tests (or none needed)
* [x] referenced any relevant issues (or none exist)

### Description

When someone logs in and has items in both their user cart (saved on their account from before) and their guest cart (attached to their session before logging in), we want to merge the two carts. The way this PR implements this is by making it so after you merge the guest cart into the user cart:
- any item in the guest cart that wasn't already in the user cart gets added
- any item with more quantity in the guest cart than the user cart had of it gets its quantity increased to match.

We remove the guest cart from the session when we merge it. Otherwise if you logged out and back in you'd get the same stuff added again.